### PR TITLE
[minor] rename package add ahmdigital scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "react-native-sheets-bottom",
+	"name": "@ahmdigital/react-native-sheets-bottom",
 	"version": "1.3.0",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-sheets-bottom",
+  "name": "@ahmdigital/react-native-sheets-bottom",
   "version": "1.3.0",
   "description": "Kind of Sheets Bottom for react native",
   "main": "index.js",


### PR DESCRIPTION
### What

Npm is unable to move the package from a personal account to a organization. The solution recommended by NPM support is to rename the package and publish it under the ahmdigital organization.
